### PR TITLE
chore: mark peer dependencies as dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@ownclouders/extension-sdk": "0.0.7",
     "@ownclouders/prettier-config": "0.0.1",
     "@ownclouders/tsconfig": "0.0.6",
+    "@ownclouders/web-client": "^10.2.0",
+    "@ownclouders/web-pkg": "^10.2.0",
     "@types/node": "20.16.11",
     "@vue/test-utils": "^2.4.6",
     "eslint": "9.12.0",
@@ -32,10 +34,6 @@
     "vue-router": "^4.2.5",
     "vue-tsc": "2.1.6",
     "vue3-gettext": "^2.4.0"
-  },
-  "peerDependencies": {
-    "@ownclouders/web-client": "^10.2.0",
-    "@ownclouders/web-pkg": "^10.2.0"
   },
   "pnpm": {
     "peerDependencyRules": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,13 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@ownclouders/web-client':
-        specifier: ^10.2.0
-        version: 10.2.0(@casl/ability@6.7.1)(@microsoft/fetch-event-source@2.0.1)(axios@1.7.7)(lodash-es@4.17.21)(luxon@3.5.0)(uuid@10.0.0)(zod@3.23.8)
-      '@ownclouders/web-pkg':
-        specifier: ^10.2.0
-        version: 10.2.0(6ttdnymi7lruj3ig5nhjilo2ey)
     devDependencies:
       '@ownclouders/eslint-config':
         specifier: 10.3.0
@@ -27,6 +20,12 @@ importers:
       '@ownclouders/tsconfig':
         specifier: 0.0.6
         version: 0.0.6
+      '@ownclouders/web-client':
+        specifier: ^10.2.0
+        version: 10.2.0(@casl/ability@6.7.1)(@microsoft/fetch-event-source@2.0.1)(axios@1.7.7)(lodash-es@4.17.21)(luxon@3.5.0)(uuid@10.0.0)(zod@3.23.8)
+      '@ownclouders/web-pkg':
+        specifier: ^10.2.0
+        version: 10.2.0(6ttdnymi7lruj3ig5nhjilo2ey)
       '@types/node':
         specifier: 20.16.11
         version: 20.16.11


### PR DESCRIPTION
Peer dependencies don't really make sense for apps, hence marking them as dev dependencies.

Regular dependencies on the other hand only make sense if apps need them in a runtime context and they don't get provided via the Web runtime.